### PR TITLE
IE11 display problems with min-width initial

### DIFF
--- a/src/styles.styl
+++ b/src/styles.styl
@@ -72,6 +72,7 @@ clock-radius = 75
 		.md-button
 			padding: 6px
 			margin: 0
+			min-width:auto
 			min-width: initial
 			line-height: inherit
 			font-size: inherit
@@ -226,7 +227,7 @@ clock-radius = 75
 					& > input
 						border: none
 						border-bottom: 1px solid black
-						text-align: right
+						text-align: center
 						font-size: 6.1rem
 						line-height: 3.0rem
 						width: 8.4rem


### PR DESCRIPTION
Calendar wasn't displayed correctly due to ie11 min-width initial, also centred text on time inputs.

old:
<img width="1585" alt="screen shot 2015-10-26 at 15 48 03" src="https://cloud.githubusercontent.com/assets/12692936/10732147/ff346eb6-7bf8-11e5-9daa-cc4ff630159a.png">

new:
<img width="1585" alt="screen shot 2015-10-26 at 15 48 59" src="https://cloud.githubusercontent.com/assets/12692936/10732180/2291ea28-7bf9-11e5-956a-0a6381e4ecd4.png">
