### PR TITLE
Date Formatting

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,7 +106,7 @@ angular.module(MODULE_NAME, [])
           }
         });
         attrs.$observe('dateFormat', val => {
-          const changeFormat =  (val === _formatMilliseconds || val === _formatISO || val === _formatRFC);
+          const changeFormat = (val === _formatMilliseconds || val === _formatISO || val === _formatRFC);
           const format = (changeFormat) ? val : _formatDate;
 
           return _dateFormat = format;

--- a/src/main.js
+++ b/src/main.js
@@ -55,9 +55,9 @@ angular.module(MODULE_NAME, [])
       },
 
       link(scope, element, attrs, ngModel) {
-        let _setViewValue = () => {
+        const _setViewValue = () => {
           let viewValue;
-          switch(_dateFormat){
+          switch (_dateFormat) {
             case _formatMilliseconds:
               viewValue = scope.date.valueOf();
               break;
@@ -139,8 +139,7 @@ angular.module(MODULE_NAME, [])
         scope.saveUpdateDate = () => true;
 
         scope.save = function () {
-          let viewValue = _setViewValue();
-          return saveFn(scope.$parent, { $value: viewValue });
+          return saveFn(scope.$parent, { $value: _setViewValue() });
         };
 
         return scope.cancel = function () {

--- a/src/main.js
+++ b/src/main.js
@@ -106,10 +106,8 @@ angular.module(MODULE_NAME, [])
           }
         });
         attrs.$observe('dateFormat', val => {
-          let format = _formatDate;
-          if (val === _formatMilliseconds || val === _formatISO || val === _formatRFC) {
-            format = val;
-          }
+          const changeFormat =  (val === _formatMilliseconds || val === _formatISO || val === _formatRFC);
+          const format = (changeFormat) ? val : _formatDate;
 
           return _dateFormat = format;
         });

--- a/src/main.js
+++ b/src/main.js
@@ -39,7 +39,7 @@ angular.module(MODULE_NAME, [])
     const _formatRFC = 'rfc';
     const _formatISO = 'iso';
 
-    var _dateFormat = _formatDate;
+    let _dateFormat = _formatDate;
 
     return {
       restrict: 'AE',
@@ -55,6 +55,27 @@ angular.module(MODULE_NAME, [])
       },
 
       link(scope, element, attrs, ngModel) {
+        let _setViewValue = () => {
+          let viewValue;
+          switch(_dateFormat){
+            case _formatMilliseconds:
+              viewValue = scope.date.valueOf();
+              break;
+            case _formatRFC:
+              viewValue = scope.date.toString();
+              break;
+            case _formatISO:
+              viewValue = scope.date.toISOString();
+              break;
+            default:
+              viewValue = scope.date;
+              break;
+          }
+
+          ngModel.$setViewValue(viewValue);
+          return viewValue;
+        };
+
         attrs.$observe('defaultMode', val => {
           if ((val !== 'time') && (val !== 'date')) { val = scDateTimeConfig.defaultMode; }
 
@@ -85,8 +106,8 @@ angular.module(MODULE_NAME, [])
           }
         });
         attrs.$observe('dateFormat', val => {
-          var format = _formatDate;
-          if(val === _formatMilliseconds || val === _formatISO || val === _formatRFC) {
+          let format = _formatDate;
+          if (val === _formatMilliseconds || val === _formatISO || val === _formatRFC) {
             format = val;
           }
 
@@ -107,27 +128,6 @@ angular.module(MODULE_NAME, [])
           angular.element(input).on('focus', () => setTimeout((() => input.select()), 10)),
       );
 
-        var _setViewValue = () => {
-          var viewValue;
-          switch(_dateFormat) {
-            case _formatMilliseconds:
-              viewValue = scope.date.valueOf();
-              break;
-            case _formatRFC:
-              viewValue = scope.date.toString();
-              break;
-            case _formatISO:
-              viewValue = scope.date.toISOString();
-              break;
-            default:
-              viewValue = scope.date;
-              break;
-          }
-
-          ngModel.$setViewValue(viewValue);
-          return viewValue;
-      };
-
         scope.autosave = false;
         if ((attrs.autosave != null) || scDateTimeConfig.autosave) {
           scope.saveUpdateDate = _setViewValue;
@@ -139,7 +139,7 @@ angular.module(MODULE_NAME, [])
         scope.saveUpdateDate = () => true;
 
         scope.save = function () {
-          var viewValue = _setViewValue();
+          let viewValue = _setViewValue();
           return saveFn(scope.$parent, { $value: viewValue });
         };
 


### PR DESCRIPTION
**Problem:**
Currently sc-date-time will transform all values passed to it's `ng-model` attribute into javascript Date objects. For example, given this template:
```
<span ng-controller="TheController">
    <time-date-picker ng-model="datetime"></time-date-picker>
</span>
```
and this controller:
```
angularModule.controller('TheController', ['$scope', function($scope) {
    $scope.datetime = new Date().valueOf();

    $scope.$watch('datetime', function() {
        console.log('datetime is a ' + (typeof $scope.datetime));
    }, true);
}]);
```
output in the console will read:
```
datetime is a number
datetime is a object
```
Initially the value passed into `ng-model` is a unix timestamp, but the directive will transform the value of `ng-model` into a JS Date object. This leads to unexpected side effects when using the directive. Note also that in order to `$watch` `datetime` successfully, `true` must be passed in as the second argument to `$watch` to enable deep watching on the value, which is more expensive, and again unexpected.

**Solution:**
This pull request adds an optional `date-format` attribute to the directive that controls how the directive exposes the date used by `ng-model`. The attribute accepts one of four values: "date", "milliseconds", "iso", or "rfc". If no value is provided, an invalid value is provided, or "date" is provided the directive retains its original behavior: all values of `ng-model` are converted to a Date object. "milliseconds" can be used in the example above to ensure that `ng-model` remains a unix timestamp. "rfc" and "iso" format the date as RFC 2822 or ISO 8601 respectively. All four format options are valid inputs to [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).